### PR TITLE
Fix zone upserting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ Arch Linux or Ubuntu
 
 ### DNS Zones
 
-| Name                 | Default/Required   | Description                                                                                                                                         |
-|----------------------|:------------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`               | :heavy_check_mark: | Name of this zone                                                                                                                                   |
-| `kind`               | `Master`           | Type of this zone (`Master`, `Slave`, or `Native`)                                                                                                  |
-| `soaEdit`            | `DEFAULT`          | SOA-EDIT value for this zone                                                                                                                        |
-| `soaEditApi`         |                    | SOA-EDIT value when using the API. Defaults to `soaEdit`                                                                                            |
-| `dnssec`             | `false`            | Enable DNSSEC and NSEC3 for this zone                                                                                                               |
-| `defaultTTL`         | :heavy_check_mark: | TTL for all RRsets with no TTL explicitly set                                                                                                       |
-| `nsec3Iterations`    | `5`                | Amount of NSEC3 iterations                                                                                                                          |
-| `nsec3Salt`          | `dada`             | Salt to use when hashing for NSEC3                                                                                                                  |
-| `defaultNameservers` | :heavy_check_mark: | List of NS records (for `Master` and `Native` zones), or list of masters (for `Slave` zones). This is only used when creating the zone from scratch |
-| `metadata`           |                    | Dict with the domain metadata. Items that are present in the database, but not here are removed                                                     |
-| `records`            | :heavy_check_mark: | List with all records in this zone (see below)                                                                                                      |
+| Name              | Default/Required     | Description                                                                                                                                           |
+|-------------------|:--------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`            | :heavy_check_mark:   | Name of this zone                                                                                                                                     |
+| `kind`            | `Master`             | Type of this zone (`Master`, `Slave`, or `Native`)                                                                                                    |
+| `soaEdit`         | :heavy_check_mark:   | SOA-EDIT value for this zone                                                                                                                          |
+| `soaEditApi`      |                      | SOA-EDIT value when using the API. Defaults to `soaEdit`                                                                                              |
+| `dnssec`          | `false`              | Enable DNSSEC and NSEC3 for this zone                                                                                                                 |
+| `defaultTTL`      | :heavy_check_mark:   | TTL for all RRsets with no TTL explicitly set                                                                                                         |
+| `nsec3Iterations` | `5`                  | Amount of NSEC3 iterations                                                                                                                            |
+| `nsec3Salt`       | `dada`               | Salt to use when hashing for NSEC3                                                                                                                    |
+| `masters`         | (:heavy_check_mark:) | List of master IPs (for `Slave` zones). This is not mandatory when creating a `Master` or `Native` zone                                               |
+| `metadata`        |                      | Dict with the domain metadata. Items that are present in the database, but not here are removed. Please do not set `SOA-EDIT` and `SOA-EDIT-API` here |
+| `records`         | :heavy_check_mark:   | List with all records in this zone (see below)                                                                                                        |
 
 ### Records
 

--- a/files/upsert-zone
+++ b/files/upsert-zone
@@ -16,7 +16,7 @@ nsec3Iterations="${8}"
 nsec3Salt="${9}"
 shift 9
 
-if [ "${#}" = 0 ]; then
+if [ "${kind}" = Slave ] && [ "${#}" = 0 ]; then
 	echo "Missing nameservers"
 	exit 1
 fi
@@ -46,11 +46,7 @@ new=0
 if ! [ "$(curl -s -o /dev/null -w "%{http_code}" -H "X-API-Key: ${apikey}" "${url}/zones/${zonename}.")" = 200 ]; then
 	# Add nameservers if needed
 	if [ "${kind}" = 'Master' ] || [ "${kind}" = 'Native' ]; then
-		json="${json::-2},\"nameservers\": ["
-		for ns in "${@}"; do
-			json="${json}\"${ns}.\","
-		done
-		json="${json::-1}]}"
+		json="${json::-2},\"nameservers\": [ \"dummy.ns.\" ]}"
 	fi
 	# Create zone
 	curl -s -o /dev/null -X POST -H "X-API-Key: ${apikey}" -d "${json}" "${url}/zones"
@@ -86,16 +82,16 @@ fi
 
 # Configure NSEC3
 if [ "${dnssec:1}" = 'rue' ]; then
-	line="$(pdnsutil show-zone "${zonename}" | grep '^Zone has NARROW hashed NSEC3 semantics, configuration: ' || :)"
+	line="$(pdnsutil show-zone "${zonename}" | grep '^Zone has hashed NSEC3 semantics, configuration: ' || :)"
 	if [ "$(echo "${line}" | wc -l )" = 0 ]; then
 		# NSEC 3 is currently disabled
-		pdnsutil set-nsec3 "${zonename}" "1 0 ${nsec3Iterations} ${nsec3Salt}" narrow
+		pdnsutil set-nsec3 "${zonename}" "1 0 ${nsec3Iterations} ${nsec3Salt}"
 		pdnsutil rectify-zone "${zonename}"
 		echo CHANGED
 	else
 		if [ "$(echo "${line}" | cut -d' ' -f 8)" != 1 ] || [ "$(echo "${line}" | cut -d' ' -f 9)" != 0 ] || [ "$(echo "${line}" | cut -d' ' -f 10)" != "${nsec3Iterations}" ] || [ "$(echo "${line}" | cut -d' ' -f 11)" != "${nsec3Salt}" ]; then
 			# Correct NSEC 3 parameters
-			pdnsutil set-nsec3 "${zonename}" "1 0 ${nsec3Iterations} ${nsec3Salt}" narrow
+			pdnsutil set-nsec3 "${zonename}" "1 0 ${nsec3Iterations} ${nsec3Salt}"
 			pdnsutil rectify-zone "${zonename}"
 			echo CHANGED
 		fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,8 @@
 
 - include: single-zone.yml
   with_items: "{{ pdns_auth_api_zones | mandatory }}"
+  loop_control:
+    loop_var: zone
 
 - name: Delete unknown zones
   command:

--- a/tasks/single-zone.yml
+++ b/tasks/single-zone.yml
@@ -1,50 +1,47 @@
 ---
-- name: Configure {{ item.name }} zone
+- name: Configure {{ zone.name }} zone
   command:
     cmd: >
-      /usr/local/bin/pdns-auth-api-upsert-zone "{{ pdns_auth_api_connect }}" "{{ pdns_auth_api_server }}"
-      "{{ item.name }}" "{{ item.kind | default('Master') }}" "{{ item.soaEdit | default('DEFAULT') }}" "{{ item.soaEditApi | default('') }}"
-      "{{ item.dnssec | default(false) }}" "{{ item.nsec3Iterations | default(5) }}" "{{ item.nsec3Salt | default('dada') }}" {{ item.defaultNameservers }}
+      /usr/local/bin/pdns-auth-api-upsert-zone "{{ pdns_auth_api_connect | mandatory }}" "{{ pdns_auth_api_server }}"
+      "{{ zone.name }}" "{{ zone.kind | default('Master') }}" "{{ zone.soaEdit | mandatory }}" "{{ zone.soaEditApi | default('') }}"
+      "{{ zone.dnssec | default(false) }}" "{{ zone.nsec3Iterations | default(5) }}" "{{ zone.nsec3Salt | default('dada') }}" {{ zone.masters | default([]) }}
   environment:
     apikey: "{{ pdns_auth_api_key }}"
   register: out
   changed_when: "'CHANGED' in out.stdout | default('')"
 
-- name: Configure domain metadata for {{ item.name }}
+- name: Configure domain metadata for {{ zone.name }}
   command:
     cmd: >
-      /usr/local/bin/pdns-auth-api-update-domain-metadata "{{ item.name }}"
+      /usr/local/bin/pdns-auth-api-update-domain-metadata "{{ zone.name }}"
       "{{ meta.key }}" {% if meta.value is iterable and meta.value is not string %}"{{ meta.value | join('" "') }}"{% else %}"{{ meta.value }}"{% endif %}
   register: out
   changed_when: "'CHANGED' in out.stdout | default('')"
-  with_dict: "{{ item.metadata }}"
+  with_dict: "{{ zone.metadata }}"
   loop_control:
     loop_var: meta
-  when: item.metadata is defined
+  when: zone.metadata is defined
 
-- name: Remove unknown metadata from {{ item.name }}
+- name: Remove unknown metadata from {{ zone.name }}
   command:
     cmd: >
-      /usr/local/bin/pdns-auth-api-delete-domain-metadata "{{ item.name }}"
-      "{{ meta.key }}"
+      /usr/local/bin/pdns-auth-api-delete-domain-metadata "{{ zone.name }}"
+      "{{ zone.metadata | default({}) | join('" "') }}"
   register: out
   changed_when: "'CHANGED' in out.stdout | default('')"
-  with_dict: "{{ item.metadata | default({'SOA-EDIT': ''}) }}"
-  loop_control:
-    loop_var: meta
 
-- name: Upsert records
+- name: Upsert records in {{ zone.name }}
   command:
     cmd: >
       /usr/local/bin/pdns-auth-api-upsert-records "{{ pdns_auth_api_connect }}" "{{ pdns_auth_api_server }}"
-      "{{ item.name }}"
+      "{{ zone.name }}"
   environment:
-    expected: "{{ item | to_json }}"
+    expected: "{{ zone | to_json }}"
     apikey: "{{ pdns_auth_api_key }}"
   register: records_out
   changed_when: "'CHANGED' in records_out.stdout | default('')"
 
 # We have to manually rectify the zone, because it's not implemented in the API yet
 - name: Rectify zone
-  command: pdnsutil rectify-zone "{{ item.name }}"
+  command: pdnsutil rectify-zone "{{ zone.name }}"
   when: records_out.changed


### PR DESCRIPTION
- Don't require master nameservers for creation
- Don't switch NSEC3 to narrow mode
- Rename loop var
- Fix deletion of zone metadata